### PR TITLE
RT parameters that can be updated

### DIFF
--- a/lib/utils/templateUtils.js
+++ b/lib/utils/templateUtils.js
@@ -28,16 +28,15 @@ const RECONCILIATION_FIELDS_TO_PUSH_ALWAYS = [
   "name_nl",
   "auto_hide_formula",
   "text_configuration",
-  "externally_managed",
-];
-
-const RECONCILIATION_FIELDS_TO_PUSH_EXTERNALLY_MANAGED = [
   "virtual_account_number",
   "reconciliation_type",
   "public",
   "allow_duplicate_reconciliations",
   "is_active",
+  "externally_managed",
 ];
+
+const RECONCILIATION_FIELDS_TO_PUSH_EXTERNALLY_MANAGED = [];
 
 // Recreate reconciliation (main and text parts)
 function constructReconciliationText(handle) {
@@ -55,6 +54,15 @@ function constructReconciliationText(handle) {
     acc[attribute] = config[attribute];
     return acc;
   }, {});
+
+  if (!RECONCILIATION_TYPE_OPTIONS.includes(attributes.reconciliation_type)) {
+    console.log(
+      `Wrong reconciliation type. It must be one of the following: ${RECONCILIATION_TYPE_OPTIONS.join(
+        ", "
+      )}. Skipping it's definition.`
+    );
+    delete attributes.reconciliation_type;
+  }
 
   attributes.text = fs.readFileSync(`${relativePath}/main.liquid`, "utf-8");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf_toolkit",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

- Parameters virtual_account_number, reconciliation_type, public, allow_duplicate_reconciliations, is_active, externally_managed should be editable now when we perform an update to an existing reconciliation
- Add a check to avoid submitting a wrong reconciliation_type.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
